### PR TITLE
Added argparse to xmldownload.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,18 @@ We also have a [project website](https://jamestingedwards.github.io/legis-hack/)
 
 Install BeautifulSoup4 (pip install beautifulsoup4 / apt-get install python-bs4)
 
-Edit xmldownload.py to set variables `start_year` and `end_year`, to determine what legislation years are to be downloaded - xmldownload.py scrapes www.legislation.govt.nz/subscribe/ to download all xmls between start_year and end_year.
+Run `xmldownload.py`, setting the arguments `-s`/`--start_year` and `-e`/`--end_year`, to determine what legislation years are to be downloaded - xmldownload.py scrapes www.legislation.govt.nz/subscribe/ to download all xmls between `start_year` and `end_year`. 
+
+The `-v`/`--verbose` tag will tell `xmldownload.py` to print the progress to the console as the pages are scraped.
 
 ```
-$ python3 xmldownload.py
+$ python3 xmldownload.py -v --start_year 1993 --end_year 1993
 
 $ python3 xmltransform.py
 
 $ python3 adoccommitter.py
 ```
+
 adoccommitter.py runs a shell script that pushes after all commits, so you will need to authenticate to your git repo
 
 As a demonstration of output, repo/legislation/ currently lists all 1993 Acts with each amendment since then as a commit (view history of each file).

--- a/xmldownload.py
+++ b/xmldownload.py
@@ -2,9 +2,11 @@ from urllib.request import Request, urlopen, urlretrieve
 from bs4 import BeautifulSoup
 import re
 import os
+import sys, argparse
 import xml.dom.minidom
 
-def read_url(url, start_year, end_year, pretty_print):
+
+def read_url(url, start_year, end_year, verbose):
     url = url.replace(" ","%20")
     req = Request(url)
     a = urlopen(req).read()
@@ -27,11 +29,11 @@ def read_url(url, start_year, end_year, pretty_print):
         if match:
             #print("Group 1: " + match.group(1))
             year = int(match.group(1))
-            if year != None and year >= start_year and <= end_year:
+            if year != None and year >= start_year and year <= end_year:
                 #print('Going in to dir ' + dirUrl)
                 
                 #Recurse in to the directory
-                read_url(dirUrl, start_year, end_year, pretty_print)
+                read_url(dirUrl, start_year, end_year, verbose)
                 
     #absolute dir the script is in
     root_path = os.path.dirname(os.path.realpath(__file__))
@@ -68,7 +70,7 @@ def read_url(url, start_year, end_year, pretty_print):
                 title = version + '_' +  title
             
             #Make the xml pretty for easy reading in the file
-            if pretty_print:
+            if verbose:
                 xmlString = xml.dom.minidom.parseString(xmlString)
                 xmlString = xmlString.toprettyxml()
 
@@ -93,5 +95,24 @@ def read_url(url, start_year, end_year, pretty_print):
             file.write(xmlString.encode('ascii', 'ignore').decode('utf-8'))
             file.close()
             print("Downloaded to: " + file_path)
-        
-read_url("http://legislation.govt.nz/subscribe/act/public", 1993, 1993, False)
+
+if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-v", "--verbose", action = "store_true", 
+        help = "Pretty print status to console")
+    parser.add_argument("-s", "--start_year",
+        help = "Collect all legislation from after this year", 
+        required = True, type = int)
+    parser.add_argument("-e", "--end_year",
+        help = "Collect all legislation up until this year", 
+        required = True, type = int)
+
+    args = parser.parse_args()
+
+    read_url(
+        "http://legislation.govt.nz/subscribe/act/public", 
+        args.start_year, 
+        args.end_year, 
+        args.verbose)


### PR DESCRIPTION
I added argparse to xmldownload.py. Now the arguments `start_year`, `end_year` and `verbose` can be added to the call in the command line.

I also noted a minor bug in line 32:
`if year != None and year >= start_year and year <= end_year:`
which I fixed.

The relevant parts of readme.md have also been changed to reflect the addition.